### PR TITLE
feat: new auth and platform endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,13 @@
 # Twitch API
-PLASMO_PUBLIC_TWITCH_CLIENT_ID=
-PLASMO_PUBLIC_TWITCH_API_URL=https://api.twitch.tv/helix
+PLASMO_PUBLIC_TWITCH_CLIENT_ID="vfir3y164p9aiv3v6nkbsjg0wdx4za" # Staging/Production
 
 # Rust Consumer API
-PLASMO_PUBLIC_API_URL=
+#PLASMO_PUBLIC_API_URL="https://twitch-extension.danielheart.dev/api/v1" # Staging/Production
+#PLASMO_PUBLIC_API_URL="http://localhost:8001" # Local (in case you're running the entire stack locally)
+PLASMO_PUBLIC_API_VERSION=v1
 
 # App Environment
 PLASMO_PUBLIC_ENVIRONMENT=development
 PLASMO_PUBLIC_STAGE=local
+#PLASMO_PUBLIC_PLATFORM_API_URL="https://tbp.danielheart.dev/api/v1" # Staging/Production
+#PLASMO_PUBLIC_PLATFORM_API_URL="http://localhost:8000/api/v1" # Local (in case you're running the entire stack locally)

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
       "identity",
       "*://*.twitch.tv/*",
       "https://twitch-extension.danielheart.dev/*",
+      "https://tbp.danielheart.dev/*",
+      "*://localhost:8000/*",
       "storage"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       "*://*.twitch.tv/*",
       "https://twitch-extension.danielheart.dev/*",
       "https://tbp.danielheart.dev/*",
-      "*://localhost:8000/*",
+      "*://localhost/*",
       "storage"
     ]
   }

--- a/src/background/messages/oauth.ts
+++ b/src/background/messages/oauth.ts
@@ -3,7 +3,14 @@ import browser from "webextension-polyfill";
 import type { PlasmoMessaging } from "@plasmohq/messaging";
 import { Storage } from "@plasmohq/storage";
 
-import type { ColorChatUser, TwitchUser, UserSettings } from "~types/types";
+import type {
+  AccessTokenResponse,
+  ColorChatUser,
+  TwitchUser,
+  User,
+  UserSettings,
+} from "~types/types";
+import { env } from "~config/env";
 
 const CLIENT_ID = process.env.PLASMO_PUBLIC_TWITCH_CLIENT_ID;
 const TWITCH_API_URL = process.env.PLASMO_PUBLIC_TWITCH_API_URL;
@@ -16,13 +23,18 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const accessToken = await authenticateWithTwitch();
   await storage.set("accessToken", accessToken);
 
-  const user = await getTwitchUserByAccessToken(accessToken);
+  let  [serverAccessToken, user] = await authenticateWithServer(accessToken);
+  user = user as User;
   await storage.set("user", user);
 
-  const settings = await getUserDataByUsername(user.login, user.id);
+  const settings = await getUserDataByUsername(
+    user.accounts[0].nickname,
+    user.accounts[0].provider_user_id,
+  );
+
   await storage.set("settings", settings);
 
-  const color = await getUserChatColor(accessToken, user.id);
+  const color = await getUserChatColor(user.accounts[0].token, user.accounts[0].provider_user_id);
   await storage.set("color", color);
 
   if (settings) {
@@ -38,7 +50,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
 
 async function getUserDataByUsername(
   username: string,
-  user_id: number,
+  user_id: string,
 ): Promise<UserSettings | null> {
   const settings = await fetch(`${API_URL}/settings/${username}`, {
     headers: {
@@ -76,7 +88,7 @@ async function getUserDataByUsername(
 
 async function getUserChatColor(
   accessToken: string,
-  userId: number,
+  userId: string,
 ): Promise<string | null> {
   const usernameColorRequest = await fetch(
     `${TWITCH_API_URL}/chat/color?user_id=${userId}`,
@@ -95,28 +107,13 @@ async function getUserChatColor(
   return "gray";
 }
 
-async function getTwitchUserByAccessToken(
-  accessToken: string,
-): Promise<TwitchUser> {
-  const authenticatedUser = await fetch(`${TWITCH_API_URL}/users`, {
-    headers: {
-      "Client-ID": CLIENT_ID,
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-  let user = await authenticatedUser.json();
-  user = user.data[0] as TwitchUser;
-  user.id = Number.parseInt(user.id);
-  return user;
-}
-
 /**
  * Authenticate with Twitch using OAuth2
  *
  * @returns string - Access Token
  */
 async function authenticateWithTwitch() {
-  const AUTH_URL = `https://id.twitch.tv/oauth2/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=token&scope=user:read:email`;
+  const AUTH_URL = `https://id.twitch.tv/oauth2/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=user:read:email`;
 
   const redirectURL = await browser.identity.launchWebAuthFlow({
     interactive: true,
@@ -125,6 +122,30 @@ async function authenticateWithTwitch() {
 
   const urlParams = new URLSearchParams(redirectURL);
   return urlParams.entries().next().value[1];
+}
+
+async function authenticateWithServer(code: string) {
+  const uri = `${env.data.APP_PLATFORM_API_URL}/authenticate/twitch?code=${code}`;
+  const response = await fetch(uri, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to authenticate with server");
+  }
+
+  let data = await response.json();
+  console.log(data);
+
+  let user = data.user as User;
+  //delete data.user;
+
+  let accessToken = data as AccessTokenResponse;
+
+  return [accessToken, user];
 }
 
 export default handler;

--- a/src/background/messages/oauth.ts
+++ b/src/background/messages/oauth.ts
@@ -5,7 +5,7 @@ import { Storage } from "@plasmohq/storage";
 
 import { env } from "~config/env";
 import { getOccupations } from "~services/occupation-service";
-import type { AccessTokenResponse, TwitchUser, User } from "~types/types";
+import { authenticateWithServer } from "~services/user/user-consumer-service";
 
 const CLIENT_ID = env.data.TWITCH_CLIENT_ID;
 
@@ -13,16 +13,14 @@ const REDIRECT_URI = browser.identity.getRedirectURL();
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const accessToken = await authenticateWithTwitch();
-  let [serverAccessToken, user, twitchUser] =
+  const { authorization, user, twitchUser } =
     await authenticateWithServer(accessToken);
-  user = user as User;
   const storage = new Storage();
 
   await storage.set("user", user);
-  await storage.set("accessToken", serverAccessToken);
+  await storage.set("accessToken", authorization);
   await storage.set("twitchUser", twitchUser);
   const occupations = await getOccupations();
-  console.log(occupations);
   await storage.set("occupations", occupations);
 
   res.send({
@@ -46,34 +44,6 @@ async function authenticateWithTwitch() {
 
   const urlParams = new URLSearchParams(redirectURL);
   return urlParams.entries().next().value[1];
-}
-
-async function authenticateWithServer(code: string) {
-  const uri = `${env.data.APP_PLATFORM_API_URL}/authenticate/twitch?code=${code}`;
-  const response = await fetch(uri, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error("Failed to authenticate with server");
-  }
-
-  const data = await response.json();
-  console.log(data);
-
-  const user = data.user as User;
-
-  const accessToken = data as AccessTokenResponse;
-  const twitchUser = {
-    id: Number.parseInt(user.accounts[0].provider_user_id),
-    login: user.accounts[0].nickname,
-    display_name: user.accounts[0].name,
-  } as TwitchUser;
-
-  return [accessToken, user, twitchUser];
 }
 
 export default handler;

--- a/src/background/messages/oauth.ts
+++ b/src/background/messages/oauth.ts
@@ -3,17 +3,15 @@ import browser from "webextension-polyfill";
 import type { PlasmoMessaging } from "@plasmohq/messaging";
 import { Storage } from "@plasmohq/storage";
 
-import type { AccessTokenResponse, TwitchUser, User } from "~types/types";
 import { env } from "~config/env";
 import { getOccupations } from "~services/occupation-service";
+import type { AccessTokenResponse, TwitchUser, User } from "~types/types";
 
 const CLIENT_ID = process.env.PLASMO_PUBLIC_TWITCH_CLIENT_ID;
 
 const REDIRECT_URI = browser.identity.getRedirectURL();
 
-
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
-
   const accessToken = await authenticateWithTwitch();
   let [serverAccessToken, user, twitchUser] =
     await authenticateWithServer(accessToken);
@@ -23,9 +21,9 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   await storage.set("user", user);
   await storage.set("accessToken", serverAccessToken);
   await storage.set("twitchUser", twitchUser);
-  let occupations = await getOccupations();
+  const occupations = await getOccupations();
   console.log(occupations);
-  await storage.set("occupations",  occupations);
+  await storage.set("occupations", occupations);
 
   res.send({
     auth: true,
@@ -63,14 +61,14 @@ async function authenticateWithServer(code: string) {
     throw new Error("Failed to authenticate with server");
   }
 
-  let data = await response.json();
+  const data = await response.json();
   console.log(data);
 
-  let user = data.user as User;
+  const user = data.user as User;
 
-  let accessToken = data as AccessTokenResponse;
-  let twitchUser = {
-    id: parseInt(user.accounts[0].provider_user_id),
+  const accessToken = data as AccessTokenResponse;
+  const twitchUser = {
+    id: Number.parseInt(user.accounts[0].provider_user_id),
     login: user.accounts[0].nickname,
     display_name: user.accounts[0].name,
   } as TwitchUser;

--- a/src/background/messages/oauth.ts
+++ b/src/background/messages/oauth.ts
@@ -7,7 +7,7 @@ import { env } from "~config/env";
 import { getOccupations } from "~services/occupation-service";
 import type { AccessTokenResponse, TwitchUser, User } from "~types/types";
 
-const CLIENT_ID = process.env.PLASMO_PUBLIC_TWITCH_CLIENT_ID;
+const CLIENT_ID = env.data.TWITCH_CLIENT_ID;
 
 const REDIRECT_URI = browser.identity.getRedirectURL();
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -27,13 +27,13 @@ const envSchema = z.object({
     .trim()
     .min(1, "PLASMO_PUBLIC_ENVIRONMENT is missing or empty"),
   APP_STAGE: z
-      .string()
-      .trim()
-      .min(1, "PLASMO_PUBLIC_STAGE is missing or empty"),
+    .string()
+    .trim()
+    .min(1, "PLASMO_PUBLIC_STAGE is missing or empty"),
   APP_PLATFORM_API_URL: z
-      .string()
-      .trim()
-      .min(1, "PLASMO_PUBLIC_PLATFORM_API_URL is missing or empty"),
+    .string()
+    .trim()
+    .min(1, "PLASMO_PUBLIC_PLATFORM_API_URL is missing or empty"),
 });
 
 const mapZodErrorMessages = (zodError: ZodError): string[] => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,27 +1,27 @@
 import { ZodError, z } from "zod";
 
 const raw_env = {
-  PLASMO_PUBLIC_TWITCH_CLIENT_ID: process.env.PLASMO_PUBLIC_TWITCH_CLIENT_ID,
-  PLASMO_PUBLIC_TWITCH_API_URL: process.env.PLASMO_PUBLIC_TWITCH_API_URL,
-  PLASMO_PUBLIC_API_URL: process.env.PLASMO_PUBLIC_API_URL,
+  TWITCH_CLIENT_ID: process.env.PLASMO_PUBLIC_TWITCH_CLIENT_ID,
+  CONSUMER_API_URL: process.env.PLASMO_PUBLIC_API_URL,
+  CONSUMER_API_VERSION: process.env.PLASMO_PUBLIC_API_VERSION,
   APP_ENVIRONMENT: process.env.PLASMO_PUBLIC_ENVIRONMENT,
   APP_STAGE: process.env.PLASMO_PUBLIC_STAGE,
   APP_PLATFORM_API_URL: process.env.PLASMO_PUBLIC_PLATFORM_API_URL,
 };
 
 const envSchema = z.object({
-  PLASMO_PUBLIC_TWITCH_CLIENT_ID: z
+  TWITCH_CLIENT_ID: z
     .string()
     .trim()
     .min(1, "PLASMO_PUBLIC_TWITCH_CLIENT_ID is missing or empty"),
-  PLASMO_PUBLIC_TWITCH_API_URL: z
-    .string()
-    .trim()
-    .min(1, "PLASMO_PUBLIC_TWITCH_API_URL is missing or empty"),
-  PLASMO_PUBLIC_API_URL: z
+  CONSUMER_API_URL: z
     .string()
     .trim()
     .min(1, "PLASMO_PUBLIC_API_URL is missing or empty"),
+  CONSUMER_API_VERSION: z
+    .string()
+    .trim()
+    .min(1, "PLASMO_PUBLIC_API_VERSION is missing or empty"),
   APP_ENVIRONMENT: z
     .string()
     .trim()

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -6,6 +6,7 @@ const raw_env = {
   PLASMO_PUBLIC_API_URL: process.env.PLASMO_PUBLIC_API_URL,
   APP_ENVIRONMENT: process.env.PLASMO_PUBLIC_ENVIRONMENT,
   APP_STAGE: process.env.PLASMO_PUBLIC_STAGE,
+  APP_PLATFORM_API_URL: process.env.PLASMO_PUBLIC_PLATFORM_API_URL,
 };
 
 const envSchema = z.object({
@@ -29,6 +30,10 @@ const envSchema = z.object({
       .string()
       .trim()
       .min(1, "PLASMO_PUBLIC_STAGE is missing or empty"),
+  APP_PLATFORM_API_URL: z
+      .string()
+      .trim()
+      .min(1, "PLASMO_PUBLIC_PLATFORM_API_URL is missing or empty"),
 });
 
 const mapZodErrorMessages = (zodError: ZodError): string[] => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from "@Components/app/theme-provide";
 import { Auth } from "@Pages/auth";
 import Profile from "@Pages/profile";
 
-import { useStorage } from "@plasmohq/storage/dist/hook";
+import { useStorage } from "@plasmohq/storage/hook";
 
 function IndexPopup() {
   const [user] = useStorage("user");

--- a/src/resources/components/settings/chat-appearance.tsx
+++ b/src/resources/components/settings/chat-appearance.tsx
@@ -3,9 +3,9 @@ import { cn } from "@Shad/lib/utils";
 import type { TwitchUser, User, UserSettings } from "~types/types";
 
 import { env } from "@Config/env";
-import { t } from "~utils/i18nUtils";
-import type UserStorageService from "~services/user/user-storage-service";
 import { useEffect, useState } from "react";
+import type UserStorageService from "~services/user/user-storage-service";
+import { t } from "~utils/i18nUtils";
 
 type ChatAppearanceProps = {
   userService: UserStorageService;
@@ -27,7 +27,7 @@ export default function ChatAppearance({ userService }: ChatAppearanceProps) {
           src={`${baseUrl}/static/icons/${occupationIcon}.png`}
           alt="logo"
         />
-        <span className={cn(`font-bold text-[gray]`)}>
+        <span className={cn("font-bold text-gray")}>
           {userService.user.name}
         </span>
         <span className="font-light text-gray-500 dark:text-gray-400">

--- a/src/resources/components/settings/chat-appearance.tsx
+++ b/src/resources/components/settings/chat-appearance.tsx
@@ -1,10 +1,8 @@
-import Logo from "data-base64:@Root/assets/icon.png";
 import { cn } from "@Shad/lib/utils";
-import type { TwitchUser, User, UserSettings } from "~types/types";
 
 import { env } from "@Config/env";
-import { useEffect, useState } from "react";
 import type UserStorageService from "~services/user/user-storage-service";
+
 import { t } from "~utils/i18nUtils";
 
 type ChatAppearanceProps = {
@@ -12,8 +10,8 @@ type ChatAppearanceProps = {
 };
 
 export default function ChatAppearance({ userService }: ChatAppearanceProps) {
-  const baseUrl = env.data.PLASMO_PUBLIC_API_URL;
-  const occupationIcon = "none";
+  const baseUrl = env.data.CONSUMER_API_URL;
+  const occupationIcon = userService.user.settings.occupation.slug;
   const settings = userService.getSettings();
 
   return (

--- a/src/resources/components/settings/chat-appearance.tsx
+++ b/src/resources/components/settings/chat-appearance.tsx
@@ -1,25 +1,20 @@
 import Logo from "data-base64:@Root/assets/icon.png";
 import { cn } from "@Shad/lib/utils";
-import type { TwitchUser } from "~types/types";
+import type { TwitchUser, User, UserSettings } from "~types/types";
 
 import { env } from "@Config/env";
 import { t } from "~utils/i18nUtils";
+import type UserStorageService from "~services/user/user-storage-service";
+import { useEffect, useState } from "react";
 
 type ChatAppearanceProps = {
-  user: TwitchUser;
-  pronouns?: string;
-  color: string;
-  occupation?: string;
+  userService: UserStorageService;
 };
 
-export default function ChatAppearance({
-  user,
-  pronouns,
-  color,
-  occupation,
-}: ChatAppearanceProps) {
+export default function ChatAppearance({ userService }: ChatAppearanceProps) {
   const baseUrl = env.data.PLASMO_PUBLIC_API_URL;
-  const occupationIcon = occupation ? occupation.toLowerCase() : "none";
+  const occupationIcon = "none";
+  const settings = userService.getSettings();
 
   return (
     <div className="flex flex-col space-y-2">
@@ -32,14 +27,12 @@ export default function ChatAppearance({
           src={`${baseUrl}/static/icons/${occupationIcon}.png`}
           alt="logo"
         />
-        <span className={cn(`font-bold text-[${color}]`)}>
-          {user.display_name}
+        <span className={cn(`font-bold text-[gray]`)}>
+          {userService.user.name}
         </span>
-        {pronouns && (
-          <span className="font-light text-gray-500 dark:text-gray-400">
-            ({t(`pronouns${pronouns.replace("/", "")}`)}):
-          </span>
-        )}
+        <span className="font-light text-gray-500 dark:text-gray-400">
+          ({t(`pronouns${settings.pronouns.replace("/", "")}`)}):
+        </span>
         <span className="font-light dark:text-gray-300">
           {t("chatAppearanceGreeting")}
         </span>

--- a/src/resources/components/settings/profile-card.tsx
+++ b/src/resources/components/settings/profile-card.tsx
@@ -1,22 +1,13 @@
-import type { User} from "~types/types";
 import { t } from "~utils/i18nUtils";
+import type { User } from "~types/types";
 
 type ProfileCardProps = {
   user: User;
-  pronouns?: string;
-  occupation?: string;
 };
 
-export default function ProfileCard({
-  user,
-  pronouns,
-  occupation,
-}: ProfileCardProps) {
+export default function ProfileCard({ user }: ProfileCardProps) {
   // frontend-engineer -> FrontEndEngineer
-  const transformedOcuppation = occupation
-    ?.split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join("");
+  const occupation = user.settings.occupation;
 
   return (
     <div className="flex items-center rounded-xl bg-muted">
@@ -37,7 +28,8 @@ export default function ProfileCard({
             className="text-gray-600 dark:text-gray-300 text-sm m-0 p-0"
             id="roleEl"
           >
-            {t(`occupation${transformedOcuppation}`) ?? t("occupationNone")}
+            {t(`occupation${occupation.translation_key}`) ??
+              t("occupationNone")}
           </p>
         </div>
         <div className="mt-2">
@@ -53,8 +45,8 @@ export default function ProfileCard({
               className="text-gray-600 dark:text-gray-300 ml-2"
               id="pronounsEl"
             >
-              {pronouns
-                ? t(`pronouns${pronouns.replace("/", "")}`)
+              {user.settings.pronouns
+                ? t(`pronouns${user.settings.pronouns.replace("/", "")}`)
                 : t("pronounsNone")}
             </span>
           </p>

--- a/src/resources/components/settings/profile-card.tsx
+++ b/src/resources/components/settings/profile-card.tsx
@@ -1,8 +1,8 @@
-import type { TwitchUser } from "~types/types";
+import type { User} from "~types/types";
 import { t } from "~utils/i18nUtils";
 
 type ProfileCardProps = {
-  user: TwitchUser;
+  user: User;
   pronouns?: string;
   occupation?: string;
 };
@@ -21,7 +21,7 @@ export default function ProfileCard({
   return (
     <div className="flex items-center rounded-xl bg-muted">
       <img
-        src={user.profile_image_url}
+        src={user.accounts[0].avatar}
         alt="The user's profile"
         className="size-28 rounded-xl p-1"
       />
@@ -31,7 +31,7 @@ export default function ProfileCard({
             className="font-extrabold text-lg m-0 line-clamp-1"
             id="usernameEl"
           >
-            {user.display_name}
+            {user.name}
           </h1>
           <p
             className="text-gray-600 dark:text-gray-300 text-sm m-0 p-0"
@@ -44,7 +44,7 @@ export default function ProfileCard({
           <p className="text-sm">
             <span className="font-bold">ID:</span>
             <span className="text-gray-600 dark:text-gray-300 ml-2" id="idEl">
-              {user.id}
+              {user.accounts[0].id}
             </span>
           </p>
           <p className="text-sm">

--- a/src/resources/components/settings/profile-card.tsx
+++ b/src/resources/components/settings/profile-card.tsx
@@ -1,5 +1,5 @@
-import { t } from "~utils/i18nUtils";
 import type { User } from "~types/types";
+import { t } from "~utils/i18nUtils";
 
 type ProfileCardProps = {
   user: User;

--- a/src/resources/components/settings/settings-form.tsx
+++ b/src/resources/components/settings/settings-form.tsx
@@ -1,59 +1,20 @@
 import { Label } from "@Shad/components/ui/label";
 import { type MutableRefObject, useRef } from "react";
 
-import { Storage } from "@plasmohq/storage";
-
-import type { TwitchUser } from "~types/types";
+import type {
+  AccessTokenResponse, Occupation,
+  TwitchUser,
+  UserSettings,
+} from "~types/types";
 import { t } from "~utils/i18nUtils";
+import UserStorageService from "~services/user/user-storage-service";
+import { useStorage } from "@plasmohq/storage/hook";
+import { env } from "~config/env";
+import { getOccupations } from "~services/occupation-service";
 
 interface SettingsFormProps {
-  user?: TwitchUser;
-  pronouns?: string;
-  occupation?: string;
+  userService: UserStorageService;
 }
-
-export const occupations = [
-  {
-    translationKey: "None",
-    apiValue: "none",
-  },
-  {
-    translationKey: "Student",
-    apiValue: "student",
-  },
-  {
-    translationKey: "Lawyer",
-    apiValue: "lawyer",
-  },
-  {
-    translationKey: "Doctor",
-    apiValue: "doctor",
-  },
-  {
-    translationKey: "CivilEngineer",
-    apiValue: "civil-engineer",
-  },
-  {
-    translationKey: "FrontEndEngineer",
-    apiValue: "frontend-engineer",
-  },
-  {
-    translationKey: "SreEngineer",
-    apiValue: "sre-engineer",
-  },
-  {
-    translationKey: "BackEndEngineer",
-    apiValue: "backend-engineer",
-  },
-  {
-    translationKey: "FullstackEngineer",
-    apiValue: "fullstack-engineer",
-  },
-  {
-    translationKey: "UxUiDesigner",
-    apiValue: "designer",
-  },
-];
 
 export const pronounsItems = [
   { apiValue: "n/d", translationKey: "None" },
@@ -73,38 +34,44 @@ export const pronounsItems = [
   { apiValue: "E/Em", translationKey: "EEm" },
 ];
 
-export default function SettingsForm({
-  user,
-  pronouns,
-  occupation,
-}: SettingsFormProps) {
+
+
+export default function SettingsForm({ userService }: SettingsFormProps) {
+  // TODO: implement caching for refreshing occupations list after 1h
+  const [occupations] = useStorage<Occupation[]>("occupations", []);
+
+  let settings = userService.getSettings();
+  const [twitchUser] = useStorage<TwitchUser>("twitchUser");
+  const [accessToken] = useStorage<AccessTokenResponse>("accessToken");
   const pronounsListEl: MutableRefObject<HTMLSelectElement> = useRef(null);
   const occupationListEl: MutableRefObject<HTMLSelectElement> = useRef(null);
 
-  const updateSettings = async () => {
-    const storage = new Storage();
+
+  const saveToDatabase = async () => {
     const selectedPronoun = pronounsListEl.current.value;
     const selectedOccupation = occupationListEl.current.value;
+
     const response = await fetch(
-      `${process.env.PLASMO_PUBLIC_API_URL}/settings`,
+      `${env.data.APP_PLATFORM_API_URL}/me/update-settings`,
       {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken.access_token}`,
         },
         body: JSON.stringify({
           pronouns: selectedPronoun,
           locale: navigator.language,
-          occupation: selectedOccupation,
-          user_id: user.id,
-          username: user.display_name,
+          occupation_id: selectedOccupation,
+          user_id: twitchUser.id,
+          username: twitchUser.login,
         }),
-      }
+      },
     );
 
     if (response.ok) {
-      await storage.set("pronouns", selectedPronoun);
-      await storage.set("occupation", selectedOccupation);
+      const updatedSettings = (await response.json()) as UserSettings;
+      await userService.updateSettings(updatedSettings);
     }
   };
 
@@ -116,8 +83,8 @@ export default function SettingsForm({
           <select
             ref={pronounsListEl}
             id="pronouns"
-            onChange={updateSettings}
-            value={pronouns}
+            onChange={saveToDatabase}
+            value={settings.pronouns}
             className="flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300"
           >
             {pronounsItems.map(({ translationKey, apiValue }) => (
@@ -133,13 +100,13 @@ export default function SettingsForm({
           <select
             ref={occupationListEl}
             id="pronouns"
-            onChange={updateSettings}
-            value={occupation}
+            onChange={saveToDatabase}
+            value={settings.occupation_id}
             className="flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300"
           >
-            {occupations.map(({ translationKey, apiValue }) => (
-              <option key={translationKey} value={apiValue}>
-                {t(`occupation${translationKey}`)}
+            {occupations.map((occupation) => (
+              <option key={occupation.id} value={occupation.id}>
+                {t(`occupation${occupation.translation_key}`)}
               </option>
             ))}
           </select>

--- a/src/resources/components/settings/settings-form.tsx
+++ b/src/resources/components/settings/settings-form.tsx
@@ -1,16 +1,16 @@
 import { Label } from "@Shad/components/ui/label";
 import { type MutableRefObject, useRef } from "react";
 
+import { useStorage } from "@plasmohq/storage/hook";
+import { env } from "~config/env";
+import type UserStorageService from "~services/user/user-storage-service";
 import type {
-  AccessTokenResponse, Occupation,
+  AccessTokenResponse,
+  Occupation,
   TwitchUser,
   UserSettings,
 } from "~types/types";
 import { t } from "~utils/i18nUtils";
-import UserStorageService from "~services/user/user-storage-service";
-import { useStorage } from "@plasmohq/storage/hook";
-import { env } from "~config/env";
-import { getOccupations } from "~services/occupation-service";
 
 interface SettingsFormProps {
   userService: UserStorageService;
@@ -34,17 +34,15 @@ export const pronounsItems = [
   { apiValue: "E/Em", translationKey: "EEm" },
 ];
 
-
 export default function SettingsForm({ userService }: SettingsFormProps) {
   // TODO: implement caching for refreshing occupations list after 1h
   const [occupations] = useStorage<Occupation[]>("occupations", []);
 
-  let settings = userService.getSettings();
+  const settings = userService.getSettings();
   const [twitchUser] = useStorage<TwitchUser>("twitchUser");
   const [accessToken] = useStorage<AccessTokenResponse>("accessToken");
   const pronounsListEl: MutableRefObject<HTMLSelectElement> = useRef(null);
   const occupationListEl: MutableRefObject<HTMLSelectElement> = useRef(null);
-
 
   const saveToDatabase = async () => {
     const selectedPronoun = pronounsListEl.current.value;

--- a/src/resources/components/settings/settings-form.tsx
+++ b/src/resources/components/settings/settings-form.tsx
@@ -35,7 +35,6 @@ export const pronounsItems = [
 ];
 
 
-
 export default function SettingsForm({ userService }: SettingsFormProps) {
   // TODO: implement caching for refreshing occupations list after 1h
   const [occupations] = useStorage<Occupation[]>("occupations", []);

--- a/src/resources/pages/profile.tsx
+++ b/src/resources/pages/profile.tsx
@@ -5,9 +5,9 @@ import SettingsForm from "@Components/settings/settings-form";
 import AboutCard from "@Components/about/about";
 import ChatAppearance from "@Components/settings/chat-appearance";
 import Tabs from "@Shad/components/ui/tabs";
-import { t } from "~utils/i18nUtils";
 import UserStorageService from "~services/user/user-storage-service";
 import type { User } from "~types/types";
+import { t } from "~utils/i18nUtils";
 
 type ProfileProps = {
   user: User;

--- a/src/resources/pages/profile.tsx
+++ b/src/resources/pages/profile.tsx
@@ -1,24 +1,20 @@
 import Header from "@Components/app/header";
 import ProfileCard from "@Components/settings/profile-card";
 import SettingsForm from "@Components/settings/settings-form";
-import { Button } from "@Shad/components/ui/button";
 
 import AboutCard from "@Components/about/about";
 import ChatAppearance from "@Components/settings/chat-appearance";
 import Tabs from "@Shad/components/ui/tabs";
-import { useStorage } from "@plasmohq/storage/dist/hook";
-
-import type { TwitchUser } from "~types/types";
 import { t } from "~utils/i18nUtils";
+import UserStorageService from "~services/user/user-storage-service";
+import type { User } from "~types/types";
 
 type ProfileProps = {
-  user: TwitchUser;
+  user: User;
 };
 
 export default function Profile({ user }: ProfileProps) {
-  const [currentPronouns] = useStorage("pronouns");
-  const [currentOccupation] = useStorage("occupation");
-  const [color] = useStorage("color");
+  const userService = new UserStorageService(user);
 
   const tabData = [
     {
@@ -26,17 +22,8 @@ export default function Profile({ user }: ProfileProps) {
       value: "settings",
       content: (
         <div className="flex flex-col w-full gap-3">
-          <SettingsForm
-            user={user}
-            pronouns={currentPronouns}
-            occupation={currentOccupation}
-          />
-          <ChatAppearance
-            user={user}
-            pronouns={currentPronouns}
-            color={color}
-            occupation={currentOccupation}
-          />
+          <SettingsForm userService={userService} />
+          <ChatAppearance userService={userService} />
         </div>
       ),
     },
@@ -50,11 +37,7 @@ export default function Profile({ user }: ProfileProps) {
   return (
     <div className="flex flex-col max-w-96 p-3 gap-3">
       <Header />
-      <ProfileCard
-        user={user}
-        pronouns={currentPronouns}
-        occupation={currentOccupation}
-      />
+      <ProfileCard user={userService.user} />
       <Tabs tabData={tabData} />
     </div>
   );

--- a/src/scripting/components.ts
+++ b/src/scripting/components.ts
@@ -1,5 +1,5 @@
-import { t } from "~utils/i18nUtils";
 import { pronounsItems } from "@Components/settings/settings-form";
+import { t } from "~utils/i18nUtils";
 
 const API_URL: string = process.env.PLASMO_PUBLIC_API_URL;
 
@@ -11,21 +11,20 @@ const SEVEN_TV_USERNAME_CONTAINER = ".seventv-chat-user-username";
 const USERNAME_CONTAINER = `${TWITCH_USERNAME_CONTAINER},${SEVEN_TV_USERNAME_CONTAINER}`;
 
 type SettingsOption = {
-    name: String,
-    slug: String,
-    translation_key: String
-
-}
+  name: string;
+  slug: string;
+  translation_key: string;
+};
 
 type ConsumerUserResponse = {
-  locale: String,
-  occupation: SettingsOption,
-  pronouns: SettingsOption,
-  timezone?: String,
-  updated_at: String,
-  user_id: number,
-  username: String
-}
+  locale: string;
+  occupation: SettingsOption;
+  pronouns: SettingsOption;
+  timezone?: string;
+  updated_at: string;
+  user_id: number;
+  username: string;
+};
 
 const enhanceChatMessage = async (messageEl: HTMLElement) => {
   const usernameEl = messageEl.querySelector(USERNAME_CONTAINER);
@@ -54,9 +53,8 @@ const enhanceChatMessage = async (messageEl: HTMLElement) => {
     return;
   }
 
-  const res = await req.json() as ConsumerUserResponse;
+  const res = (await req.json()) as ConsumerUserResponse;
   const child = usernameEl.firstChild;
-
 
   const i18nPronouns = t(`pronouns${res.pronouns.translation_key}`);
   const pronounsElement = document.createElement("span");
@@ -104,7 +102,7 @@ async function enhanceTwitchPopover(nameCard: Node, detailsCard: Node) {
     return;
   }
 
-  const res = await req.json() as ConsumerUserResponse;
+  const res = (await req.json()) as ConsumerUserResponse;
 
   const i18nPronouns = t(`pronouns${res.pronouns.translation_key}`);
   // @ts-ignore

--- a/src/scripting/components.ts
+++ b/src/scripting/components.ts
@@ -1,6 +1,5 @@
 import { t } from "~utils/i18nUtils";
-import { useStorage } from "@plasmohq/storage/dist/hook";
-import { occupations, pronounsItems } from "@Components/settings/settings-form";
+import { pronounsItems } from "@Components/settings/settings-form";
 
 const API_URL: string = process.env.PLASMO_PUBLIC_API_URL;
 
@@ -94,8 +93,7 @@ async function enhanceTwitchPopover(nameCard: Node, detailsCard: Node) {
   const i18nPronouns = t(`pronouns${currentPronoun.translationKey}`);
   // @ts-ignore
   nameCard.innerHTML += `<span class="pronouns-card">(${i18nPronouns})</span>`;
-  let occupationObject = occupations.find((o) => o.apiValue === res.occupation);
-  const occupation = t(`occupation${occupationObject.translationKey}`);
+  const occupation = t(`occupationNone`);
 
   const occupationContainer = document.createElement("div");
   occupationContainer.className = "occupation-job";

--- a/src/services/occupation-service.ts
+++ b/src/services/occupation-service.ts
@@ -1,0 +1,10 @@
+import { env } from "~config/env";
+import type { Occupation } from "~types/types";
+
+export async function getOccupations(): Promise<Occupation[]> {
+  const response = await fetch(`${env.data.APP_PLATFORM_API_URL}/occupations`);
+  if (!response.ok) {
+    return [];
+  }
+  return (await response.json()) as Occupation[];
+}

--- a/src/services/user/user-consumer-service.ts
+++ b/src/services/user/user-consumer-service.ts
@@ -1,0 +1,38 @@
+import { env } from "~config/env";
+
+const API_URL = env.data.CONSUMER_API_URL;
+const API_VERSION = env.data.CONSUMER_API_VERSION;
+
+const BASE_URL = `${API_URL}/api/${API_VERSION}`;
+
+console.log(BASE_URL);
+
+export type SettingsOption = {
+  name: string;
+  slug: string;
+  translation_key: string;
+};
+
+export type ConsumerUserResponse = {
+  locale: string;
+  occupation: SettingsOption;
+  pronouns: SettingsOption;
+  timezone?: string;
+  updated_at: string;
+  user_id: number;
+  username: string;
+};
+
+export async function getUserFromConsumer(
+  username: string,
+): Promise<ConsumerUserResponse> {
+  const uri = `${BASE_URL}/settings/${username}`;
+  console.log(uri);
+  const req = await fetch(uri);
+
+  if (!req.ok) {
+    return;
+  }
+
+  return (await req.json()) as ConsumerUserResponse;
+}

--- a/src/services/user/user-storage-service.ts
+++ b/src/services/user/user-storage-service.ts
@@ -1,5 +1,5 @@
-import type { User, UserSettings } from "~types/types";
 import { Storage } from "@plasmohq/storage";
+import type { User, UserSettings } from "~types/types";
 
 export default class UserStorageService {
   user: User;

--- a/src/services/user/user-storage-service.ts
+++ b/src/services/user/user-storage-service.ts
@@ -1,0 +1,21 @@
+import type { User, UserSettings } from "~types/types";
+import { Storage } from "@plasmohq/storage";
+
+export default class UserStorageService {
+  user: User;
+  storageAccessor: Storage;
+
+  constructor(user: User) {
+    this.user = user;
+    this.storageAccessor = new Storage();
+  }
+
+  getSettings(): UserSettings {
+    return this.user.settings;
+  }
+
+  async updateSettings(settings: UserSettings): Promise<void> {
+    this.user.settings = settings;
+    await this.storageAccessor.set("user", this.user);
+  }
+}

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -10,11 +10,6 @@ export interface TwitchUser {
   view_count: number;
   email: string;
   created_at: string;
-
-  // Custom fields
-  pronouns?: string;
-  occupation?: string;
-  color?: string;
 }
 
 export interface UserSettings {
@@ -32,4 +27,61 @@ interface ColorChatUser {
     user_id: string;
     color: string;
   }[];
+}
+
+export interface AccessTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_at: string;
+}
+
+export  interface User {
+  name: string;
+  email: string;
+  updated_at: string;
+  created_at: string;
+  id: number;
+  is_admin: boolean;
+  settings: UserSettings;
+  accounts: Account[];
+}
+
+export  interface UserSettings {
+  id: number;
+  user_id: number;
+  occupation_id: number;
+  pronouns: string;
+  timezone: string;
+  locale: string;
+  is_developer: boolean;
+  created_at: string;
+  updated_at: string;
+  occupation: Occupation;
+}
+
+export interface Occupation {
+  id: number;
+  name: string;
+  slug: string;
+  translation_key: string;
+  created_at: string;
+  updated_at: string;
+  image_url: string;
+}
+
+export interface Account {
+  id: number;
+  user_id: number;
+  provider: string;
+  provider_user_id: string;
+  name: string;
+  nickname: string;
+  email: string;
+  phone: string | null;
+  avatar: string;
+  token: string;
+  refresh_token: string;
+  expires_at: string;
+  created_at: string;
+  updated_at: string;
 }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -10,7 +10,7 @@ export interface AccessTokenResponse {
   expires_at: string;
 }
 
-export  interface User {
+export interface User {
   name: string;
   email: string;
   updated_at: string;
@@ -21,7 +21,7 @@ export  interface User {
   accounts: Account[];
 }
 
-export  interface UserSettings {
+export interface UserSettings {
   id: number;
   user_id: number;
   occupation_id: number;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -2,31 +2,6 @@ export interface TwitchUser {
   id: number;
   login: string;
   display_name: string;
-  type: string;
-  broadcaster_type: string;
-  description: string;
-  profile_image_url: string;
-  offline_image_url: string;
-  view_count: number;
-  email: string;
-  created_at: string;
-}
-
-export interface UserSettings {
-  user_id?: int;
-  username?: string;
-  locale?: string;
-  timezone?: string;
-  occupation?: string;
-  pronouns?: string;
-  updated_at?: string;
-}
-
-interface ColorChatUser {
-  data: {
-    user_id: string;
-    color: string;
-  }[];
 }
 
 export interface AccessTokenResponse {
@@ -64,8 +39,6 @@ export interface Occupation {
   name: string;
   slug: string;
   translation_key: string;
-  created_at: string;
-  updated_at: string;
   image_url: string;
 }
 


### PR DESCRIPTION
## Motivation

As explained at the https://github.com/basementdevs/twitch-better-profile/issues/53, now the authentication will be directly with the platform instead just let the person login through the extension.

This PR removes all the old logic related to how the user is handled through the components (which I have no idea if it's good or not) and load the `occupations` dynamically.

About the `color` properties, IMHO it would be better to get through our own settings, so sooner we can add it at `settings` object a field for `hex` defined by @nexturhe4rt that the person can choose.

## Changes 

- [x] Authentication with Platform
- [x] Loading `occupations` dynamically
- [x] Chat Occupations (needs refactoring on tbp-consumer-api)


Closes https://github.com/basementdevs/twitch-better-profile/issues/53